### PR TITLE
Add autosaves on collectibles

### DIFF
--- a/LibertyTweaks/Enhancements/Misc/AutosaveOnCollectibles.cs
+++ b/LibertyTweaks/Enhancements/Misc/AutosaveOnCollectibles.cs
@@ -72,11 +72,7 @@ namespace LibertyTweaks
                     AutosaveOnChange(tickSeagullsTLAD, ref seagullsTLAD);
                     break;
                 case 2:
-                    /* need to find the value for tbogt
-                    if (tickSeagullsTBoGT == 50)
-                        return;
                     AutosaveOnChange(tickSeagullsTBoGT, ref seagullsTBoGT);
-                    */
                     break;
             }
         }

--- a/LibertyTweaks/Enhancements/Misc/AutosaveOnCollectibles.cs
+++ b/LibertyTweaks/Enhancements/Misc/AutosaveOnCollectibles.cs
@@ -1,0 +1,66 @@
+﻿using CCL.GTAIV;
+
+using IVSDKDotNet;
+using IVSDKDotNet.Enums;
+using IVSDKDotNet.Native;
+using static IVSDKDotNet.Native.Natives;
+
+// Credits: Gillian
+
+namespace LibertyTweaks
+{
+    internal class AutosaveOnCollectibles
+    {
+        private static bool enableFix;
+        private static bool firstCheck = true;
+        private static int dlc;
+        private static int pigeons;
+        private static int stuntJumps;
+        private static int seagullsTLAD;
+
+        public static void Init(SettingsFile settings)
+        {
+            enableFix = settings.GetBoolean("Autosave on Collectibles", "Enable", true);
+        }
+
+        private static void AutosaveOnChange(int tickValue, int value)
+        {
+            // check the stats, and if the value got incremented, autosave
+            if (tickValue > value)
+            {
+                value = tickValue;
+                if (!firstCheck)
+                {
+                    NativeGame.DoAutoSave();
+                }
+                else
+                {
+                    firstCheck = false;
+                }
+            }
+        }
+
+        public static void Tick()
+        {
+            if (!enableFix)
+                return;
+            bool autoSaveStatus = Natives.GET_IS_AUTOSAVE_OFF();
+            if (autoSaveStatus == true)
+                return;
+
+            // get the stats
+            int tickPigeons = Natives.GET_INT_STAT(361);
+            int tickStuntJumps = Natives.GET_INT_STAT(270);
+            if (tickPigeons == 200 && tickStuntJumps == 50)
+                return;
+            int tickSeagullsTLAD = Natives.GET_INT_STAT(143);
+            if (tickSeagullsTLAD == 50)
+                return;
+
+            // check the code for this above
+            AutosaveOnChange(tickPigeons, pigeons);
+            AutosaveOnChange(tickStuntJumps, stuntJumps);
+            AutosaveOnChange(tickSeagullsTLAD, seagullsTLAD);
+        }
+    }
+}

--- a/LibertyTweaks/LibertyTweaks.csproj
+++ b/LibertyTweaks/LibertyTweaks.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Enhancements\Dialogue\SearchBody.cs" />
     <Compile Include="Enhancements\Dialogue\VLikeScreaming.cs" />
     <Compile Include="Enhancements\Misc\QuickSave.cs" />
+    <Compile Include="Enhancements\Misc\AutosaveOnCollectibles.cs" />
     <Compile Include="Enhancements\Misc\ToggleHUD.cs" />
     <Compile Include="Enhancements\Misc\TweakableFOV.cs" />
     <Compile Include="Fixes\BrakeLights.cs" />

--- a/LibertyTweaks/Main.cs
+++ b/LibertyTweaks/Main.cs
@@ -4,11 +4,11 @@ using IVSDKDotNet;
 
 namespace LibertyTweaks
 {
-    public class Main : Script 
+    public class Main : Script
     {
 
         #region Variables
-        private static Random rnd; 
+        private static Random rnd;
 
         public float fovMulti;
         public int pedAccuracy;
@@ -34,7 +34,7 @@ namespace LibertyTweaks
         #endregion
 
         #region Constructor
-        public Main() 
+        public Main()
         {
             rnd = new Random();
 
@@ -64,6 +64,7 @@ namespace LibertyTweaks
             RemoveWeapons.Init(Settings);
             TweakableFOV.Init(Settings);
             QuickSave.Init(Settings);
+            AutosaveOnCollectibles.Init(Settings);
             BrakeLights.Init(Settings);
             MoreCombatLines.Init(Settings);
             SearchBody.Init(Settings);
@@ -124,6 +125,7 @@ namespace LibertyTweaks
             ArmoredCops.Tick(armoredCopsStars);
             UnseenSlipAway.Tick(timer, unseenSlipAwayMinTimer, unseenSlipAwayMaxTimer);
             RegenerateHP.Tick(timer, regenHealthMinTimer, regenHealthMaxTimer, regenHealthMinHeal, regenHealthMaxHeal);
+            AutosaveOnCollectibles.Tick();
             //StunPunch.Tick();
             CarFireBreakdown.Tick();
             //DeathBlips.Tick();


### PR DESCRIPTION
Will autosave the game when killing a pigeon, seagull or doing a stunt jump if the autosaves and the option are enabled. Hopefully made sure to include enough checks to avoid unnecessary runs or making sure the savefile changed, although it's probably still full of bad practices. Feel free to comment for any changes.

Also add this to the config:
```ini
[Autosave on Collectibles]
Enable=1
```

Granted, a better implementation would be to hijack the game's function for increasing the stat when you collect a collectible, but I'm unable to do so.