### PR TITLE
NOoSE Ragdoll Alternative + Disable HUD when blindfiring

### DIFF
--- a/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
+++ b/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
@@ -19,6 +19,7 @@ namespace LibertyTweaks
         private static bool enableNoRagdollNOoSE;
         public static bool enableVests;
         public static int ragdollTime;
+        public static int ragdollTimeShotgun;
 
         private static readonly List<int> copsWithArmor = new List<int>();
 
@@ -121,7 +122,17 @@ namespace LibertyTweaks
                     CheckDateTime = true;
                 }
 
-                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTime)
+                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTime && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 10) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 11) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 22) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 26) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 30) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 31))
+                {
+                    CheckDateTime = false;
+                    if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
+                    {
+                        SWITCH_PED_TO_ANIMATED(pedHandle, false);
+                    }
+                    CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
+                }
+
+                else if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTimeShotgun)
                 {
                     CheckDateTime = false;
                     if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))

--- a/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
+++ b/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
@@ -12,8 +12,6 @@ namespace LibertyTweaks
 {
     internal class ArmoredCops
     {
-        private static bool CheckDateTime;
-        private static DateTime currentDateTime;
         private static bool enable;
         private static bool enableNoHeadshotNOoSE;
         private static bool enableNoRagdollNOoSE;
@@ -117,30 +115,24 @@ namespace LibertyTweaks
 
             if (enableNoRagdollNOoSE && !IS_CHAR_ON_FIRE(pedHandle) && noosePed.GetHeightAboveGround() < 3 && IS_PED_RAGDOLL(pedHandle) && HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 57))
             {
-                if (CheckDateTime == false)
+                if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 10) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 11) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 22) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 26) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 30) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 31))
                 {
-                    currentDateTime = DateTime.Now;
-                    CheckDateTime = true;
+                    Main.TheDelayedCaller.Add(TimeSpan.FromMilliseconds(ragdollTime), "Main", () =>
+                    {
+                        if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
+                            SWITCH_PED_TO_ANIMATED(pedHandle, false);
+                        CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
+                    });
                 }
 
-                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTime && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 10) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 11) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 22) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 26) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 30) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 31))
+                else
                 {
-                    CheckDateTime = false;
-                    if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
+                    Main.TheDelayedCaller.Add(TimeSpan.FromMilliseconds(ragdollTimeShotgun), "Main", () =>
                     {
-                        SWITCH_PED_TO_ANIMATED(pedHandle, false);
-                    }
-                    CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
-                }
-
-                else if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTimeShotgun)
-                {
-                    CheckDateTime = false;
-                    if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
-                    {
-                        SWITCH_PED_TO_ANIMATED(pedHandle, false);
-                    }
-                    CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
+                        if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
+                            SWITCH_PED_TO_ANIMATED(pedHandle, false);
+                        CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
+                    });
                 }
             }
         }

--- a/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
+++ b/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
@@ -36,6 +36,7 @@ namespace LibertyTweaks
             enableNoHeadshotNOoSE = settings.GetBoolean("Improved Police", "No Headshot NOoSE", true);
             enableNoRagdollNOoSE = settings.GetBoolean("Improved Police", "No Ragdoll NOoSE", true);
             ragdollTime = settings.GetInteger("Improved Police", "NOoSE Ragdoll Time", 100);
+            ragdollTimeShotgun = settings.GetInteger("Improved Police", "NOoSE Shotgun Ragdoll Time", 250);
             armoredCopsStars = settings.GetInteger("Improved Police", "Armored Cops Start At", 4);
 
             if (enable)

--- a/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
+++ b/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
@@ -4,6 +4,7 @@ using static IVSDKDotNet.Native.Natives;
 using CCL.GTAIV;
 using IVSDKDotNet.Enums;
 using System.Diagnostics;
+using System;
 
 // Credits: catsmackaroo, ItsClonkAndre, GQComms
 
@@ -11,6 +12,8 @@ namespace LibertyTweaks
 {
     internal class ArmoredCops
     {
+        private static bool CheckDateTime;
+        private static DateTime currentDateTime;
         private static bool enable;
         private static bool enableNoHeadshotNOoSE;
         private static bool enableNoRagdollNOoSE;
@@ -108,8 +111,24 @@ namespace LibertyTweaks
             if (enableNoHeadshotNOoSE)
                 noosePed.PedFlags.NoHeadshots = headgearIndex != -1; // Enable if ped has headgear
 
-            if (enableNoRagdollNOoSE && !IS_CHAR_ON_FIRE(pedHandle))
-                noosePed.PreventRagdoll(true);
+            if (enableNoRagdollNOoSE && !IS_CHAR_ON_FIRE(pedHandle) && noosePed.GetHeightAboveGround() < 3 && IS_PED_RAGDOLL(pedHandle) && HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 57))
+            {
+                if (CheckDateTime == false)
+                {
+                    currentDateTime = DateTime.Now;
+                    CheckDateTime = true;
+                }
+
+                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > 100.0)
+                {
+                    CheckDateTime = false;
+                    if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))
+                    {
+                        SWITCH_PED_TO_ANIMATED(pedHandle, false);
+                    }
+                    CLEAR_CHAR_LAST_WEAPON_DAMAGE(pedHandle);
+                }
+            }
         }
 
         // Determine if player is using sniper

--- a/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
+++ b/LibertyTweaks/Enhancements/Combat/ArmoredCops.cs
@@ -18,6 +18,7 @@ namespace LibertyTweaks
         private static bool enableNoHeadshotNOoSE;
         private static bool enableNoRagdollNOoSE;
         public static bool enableVests;
+        public static int ragdollTime;
 
         private static readonly List<int> copsWithArmor = new List<int>();
 
@@ -33,6 +34,7 @@ namespace LibertyTweaks
             enableVests = settings.GetBoolean("Improved Police", "Armored Cops Have Vests", true);
             enableNoHeadshotNOoSE = settings.GetBoolean("Improved Police", "No Headshot NOoSE", true);
             enableNoRagdollNOoSE = settings.GetBoolean("Improved Police", "No Ragdoll NOoSE", true);
+            ragdollTime = settings.GetInteger("Improved Police", "NOoSE Ragdoll Time", 100);
             armoredCopsStars = settings.GetInteger("Improved Police", "Armored Cops Start At", 4);
 
             if (enable)
@@ -119,7 +121,7 @@ namespace LibertyTweaks
                     CheckDateTime = true;
                 }
 
-                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > 100.0)
+                if (DateTime.Now.Subtract(currentDateTime).TotalMilliseconds > ragdollTime)
                 {
                     CheckDateTime = false;
                     if (!HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 49) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 50) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 51) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 54) && !HAS_CHAR_BEEN_DAMAGED_BY_WEAPON(pedHandle, 55))

--- a/LibertyTweaks/Enhancements/Combat/BlindFireDisableHUD.cs
+++ b/LibertyTweaks/Enhancements/Combat/BlindFireDisableHUD.cs
@@ -28,7 +28,7 @@ namespace LibertyTweaks
             {
                 if (isInBlindCover(Main.PlayerPed) && HudIsOn)
                     DISPLAY_HUD(false);
-                else if (!isInBlindCover(Main.PlayerPed) && !HudIsOn)
+                else if (!isInBlindCover(Main.PlayerPed) && HudIsOn)
                     DISPLAY_HUD(true);
             }
         }

--- a/LibertyTweaks/Enhancements/Combat/BlindFireDisableHUD.cs
+++ b/LibertyTweaks/Enhancements/Combat/BlindFireDisableHUD.cs
@@ -1,0 +1,36 @@
+﻿using IVSDKDotNet;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using static IVSDKDotNet.Native.Natives;
+using CCL.GTAIV;
+using System.IO;
+using System.Diagnostics;
+using System;
+using System.Numerics;
+using IVSDKDotNet.Native;
+
+namespace LibertyTweaks
+{
+    internal class BlindFireDisableHUD
+    {
+        private static bool enable;
+        private static bool isAiming(IVPed ped) => IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@handgun", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@handgun", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@deagle", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@deagle", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@uzi", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@uzi", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@mp5k", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@mp5k", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@sawnoff", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@sawnoff", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@shotgun", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@shotgun", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@baretta", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@baretta", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@cz75", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@cz75", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@grnde_launch", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@grnde_launch", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@p90", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@p90", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@gold_uzi", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@gold_uzi", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@aa12", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@aa12", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@44a", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@44a", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@ak47", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@ak47", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@ak47", "fire_up") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@ak47", "fire_down") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@test_gun", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@test_gun", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@test_gun", "fire_up") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@test_gun", "fire_down") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@m249", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@m249", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@m249", "fire_up") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@m249", "fire_down") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@rifle", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@rifle", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@rifle", "fire_alt") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@rifle", "fire_crouch_alt") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@dsr1", "fire") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@dsr1", "fire_crouch") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@dsr1", "fire_alt") || IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "gun@dsr1", "fire_crouch_alt");
+        private static bool isInBlindCover(IVPed ped) => IS_PED_IN_COVER(Main.PlayerPed.GetHandle()) && !isAiming(ped) && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_high_corner", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_high_corner", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_high_corner", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_high_corner", "rifle_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_high_corner", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_high_corner", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_high_corner", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_high_corner", "rifle_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_corner", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_corner", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_corner", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_corner", "rifle_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_corner", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_corner", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_corner", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_corner", "rifle_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_centre", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_centre", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_centre", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_l_low_centre", "rifle_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_centre", "pistol_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_centre", "rifle_normal_fire_intro") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_centre", "pistol_peek") && !IS_CHAR_PLAYING_ANIM(Main.PlayerPed.GetHandle(), "cover_r_low_centre", "rifle_peek");
+
+        public static void Init(SettingsFile settings)
+        {
+            enable = settings.GetBoolean("BlindFire Disable HUD", "Enable", true);
+        }
+        public static void Tick()
+        {
+            bool HudIsOn = IVMenuManager.HudOn;
+            if (enable)
+            {
+                if (isInBlindCover(Main.PlayerPed) && HudIsOn)
+                    DISPLAY_HUD(false);
+                else if (!isInBlindCover(Main.PlayerPed) && !HudIsOn)
+                    DISPLAY_HUD(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alternative way to handle NOoSE ragdolls, makes them ragdoll but only for a brief amount of time. Fixes issues with them being being non-ragdollable to the player only while allowing them to still ragdoll by other means of damage such as being run over, falling, explosions, etc. How long they recover from being ragdolled by being shot can be tweaked in the ,ini as well.

Also added a feature from InfamousSabre's RealRecoil script that disables the HUD when blindfiring to make it less OP.

Add this to the .ini:

[Improved Police]
NOoSE Ragdoll Time = 100
NOoSE Shotgun Ragdoll Time = 250

[BlindFire Disable HUD]
Enable=1
